### PR TITLE
Update docker file to build rest-api.

### DIFF
--- a/docker/rest-api/Dockerfile
+++ b/docker/rest-api/Dockerfile
@@ -1,7 +1,20 @@
-FROM ubuntu:18.04
-EXPOSE 5000
+# Build Stage
+#  - Compiles rest-api using JDK and Gradle.
+#  - Automatically discarded after build is complete.
+FROM openjdk:11.0.2-jdk-stretch AS build
+ADD https://downloads.gradle.org/distributions/gradle-5.2.1-bin.zip /tmp/gradle.zip
+WORKDIR /opt
+RUN unzip /tmp/gradle.zip
+COPY src /rest-api/src
+COPY build.gradle /rest-api
 WORKDIR /rest-api
-COPY build/libs/rest-api-0.0.1-SNAPSHOT.jar rest-api.jar
+RUN /opt/gradle-5.2.1/bin/gradle build --stacktrace --info --debug
+
+# Runtime Image
+#  - Copies build artifact out of Build stage into much smaller JRE runtime image.
+FROM openjdk:11.0.2-jre-stretch
+EXPOSE 5000
+WORKDIR /opt/rest-api
+COPY --from=build /rest-api/build/libs/rest-api-0.0.1-SNAPSHOT.jar rest-api.jar
 COPY docker/rest-api/application.properties config/application.properties
-RUN apt-get update && apt-get install openjdk-8-jre -y
 ENTRYPOINT java -jar rest-api.jar flywayMigrate && java -jar rest-api.jar


### PR DESCRIPTION
This change updates the rest-api dockerfile
to use the Dockerfile [multistage build](https://docs.docker.com/develop/develop-images/multistage-build/) process.

Using a multistage build allows us to ensure all developers have a
consistent build environment with minimal effort on their part to
configure it.  Encapsulating our build steps in the Dockerfile also
simplifies the work required to create a continuous integration pipeline.

#1